### PR TITLE
eunit execution failiures fixed

### DIFF
--- a/test/erlocipool_test.erl
+++ b/test/erlocipool_test.erl
@@ -11,11 +11,9 @@
 -define(USER, <<"scott">>).
 -define(PASSWORD, <<"regit">>).
 
-logfun(_Log) -> ok.
 -define(USINGPOOL(__Name, __Opts, __Body),
         (fun() ->
-                 {ok, Pool} = erlocipool:new(__Name, ?TNS, ?USER, ?PASSWORD,
-                                             [{logfun, fun logfun/1}|__Opts]),
+                 {ok, Pool} = erlocipool:new(__Name, ?TNS, ?USER, ?PASSWORD, __Opts),
                  (fun Sessions() ->
                     case Pool:get_stats() of
                         [] ->
@@ -123,16 +121,14 @@ pool_test_() ->
                 OciPort = erloci:new(
                             [{logging, true},
                              {env, [{"NLS_LANG",
-                                     "GERMAN_SWITZERLAND.AL32UTF8"}]}],
-                            fun logfun/1),
+                                     "GERMAN_SWITZERLAND.AL32UTF8"}]}]),
                 OciSession = OciPort:get_session(?TNS, ?USER, ?PASSWORD),
                 Stmt = OciSession:prep_sql(?SESSSQL),
                 {cols, _} = Stmt:exec_stmt(),
                 {{rows, SessBeforePool}, true} = Stmt:fetch_rows(10000),
                 ok = Stmt:close(),
                 {ok, Pool} = erlocipool:new(test_pub, ?TNS, ?USER, ?PASSWORD,
-                                        [{logfun, fun logfun/1},
-                                         {type, public}, {sess_min, 2},
+                                        [{type, public}, {sess_min, 2},
                                          {sess_max, 4}, {stmt_max, 1},
                                          {up_th, 50}, {down_th, 40}]),
                 timer:sleep(500),
@@ -231,6 +227,6 @@ stmts(Pool, N) -> stmts(Pool, N, []).
 stmts(_Pool, 0, Acc) -> lists:reverse(Acc);
 stmts(Pool, N, Acc) when N > 0 ->
     {ok, Stmt} = Pool:prep_sql(<<"select * from dual">>),
-    ?assertEqual({cols, [{<<"DUMMY">>,'SQLT_CHR',1,0,0}]}, Stmt:exec_stmt()),
+    ?assertEqual({cols, [{<<"DUMMY">>,'SQLT_CHR',2,0,0}]}, Stmt:exec_stmt()),
     ?assertEqual({{rows, [[<<"X">>]]}, true}, Stmt:fetch_rows(2)),
     stmts(Pool, N-1, [Stmt | Acc]).


### PR DESCRIPTION
- logFun for erloci have to be an exported function or a default fun is used by erloci
- `select * from dual` return correction