### PR TITLE
Using kill(demonitoring session) in check_reduce

### DIFF
--- a/src/erlocipool_worker.erl
+++ b/src/erlocipool_worker.erl
@@ -308,9 +308,7 @@ handle_info({check_reduce, ToClose},
                    [#session{ssn = {oci_port, PortPid, _} = OciSession,
                              openStmts = 0} | Sessions]} = State)
   when ToClose > 0 ->
-    OciSession:close(),
-    OciPort = {oci_port, PortPid},
-    OciPort:close(),
+    gen_server:cast(self(), {kill, OciSession}),
     self() ! {check_reduce, ToClose - 1},
     {noreply, State#state{sessions = sort_sessions(Sessions)}};
 handle_info({check_reduce, _}, State) ->

--- a/test/erlocipool_test.erl
+++ b/test/erlocipool_test.erl
@@ -145,6 +145,7 @@ pool_test_() ->
                            lists:flatten(SessAfterPool), PoolSessns]),
                 ?assertEqual(ok, application:stop(erlocipool)),
                 Stmt1 = OciSession:prep_sql(?SESSSQL),
+                timer:sleep(2000),
                 ?assertMatch({cols, _}, Stmt1:exec_stmt()),
                 ?assertEqual({{rows, SessBeforePool}, true},
                              Stmt1:fetch_rows(10000)),
@@ -226,6 +227,8 @@ bad_conn_recover({Pool, _OciPort, OciSession, SessBefore}) ->
     ?assertMatch({error, _}, S:exec_stmt()),
     %% Pool replenished with new sessions
     ?assertMatch([#{closed_stmts := 0, open_stmts := 0},
+                  #{closed_stmts := 0, open_stmts := 0},
+                  #{closed_stmts := 0, open_stmts := 0},
                   #{closed_stmts := 0, open_stmts := 0}], Pool:get_stats()).
 
 %------------------------


### PR DESCRIPTION
When a session was killed while shrinking the pool it was being recreated immediately as the monitoring was not removed. This pr removes the monitoring on killing a session from the check_reduce